### PR TITLE
Improve project selection #21

### DIFF
--- a/src/Components/ProjectCard.jsx
+++ b/src/Components/ProjectCard.jsx
@@ -1,15 +1,26 @@
 import './ProjectCard.css'
 
-function ProjectCard({ title, image, classes, tools, description, img_height, card_width, link }) {
+function ProjectCard({ title, image, classes, tools, description, img_height, card_width, link, links}) {
     return <div className={classes ? "card project-card mb-2" + classes : "card project-card mb-3"} style={{ width: "100%", maxWidth: 400, minWidth:300 }}>
         <img className="card-img-top" src={`static/` + image} />
         <div className="card-body">
             <h5 className="card-title" style={{ color: 'white' }}>{title}</h5>
             <p style={{ color: 'white' }}>{description}</p>
-            <a href={"https://github.com/Santhosh-Paramasivam/" + link} className='link-light link-underline-opacity-0'>
+            { link && <a href={"https://github.com/Santhosh-Paramasivam/" + link} className='link-light link-underline-opacity-0'>
                 <img src={`static/github.png`} alt="GitHub Icon" width="20px" className='icon mx-2 mb-1' />
                 Github
             </a>
+            }
+            { links && 
+                links.map((_) => {
+                    if(_.type === 'Github') return <><div className="mt-2"><a href={"https://github.com/Santhosh-Paramasivam/" + _.link} className='link-light link-underline-opacity-0'>
+                    <img src={`static/github.png`} alt="GitHub Icon" width="20px" className='icon mx-2 mb-1' />
+                    {_.title}
+                    </a>
+                    </div>
+                    </>
+                })    
+            }
         </div>
 
         {tools && <div className='card-footer d-flex flex-row justify-content-end g-5 px-1'>

--- a/src/Pages/Projects/FeaturedProjects.jsx
+++ b/src/Pages/Projects/FeaturedProjects.jsx
@@ -27,7 +27,7 @@ function FeaturedProjects() {
                     image="campusfind_admin.jpeg"
                     tools={['React', 'Spring Boot', 'Firebase']}
                     description={"A full-stack website to register your organization and manage its presence on CampusFind"}
-                    link="CampusFind-Admin_Backend.git"
+                    links = {[{ type:'Github', link:"campusfind-admin-frontend", title:"Frontend" }, { type: 'Github', link:"campusfind-admin-backend.git", title: "Backend" }]}
                 />
             </div>
           <div className="col d-flex flex-row justify-content-around">

--- a/src/Pages/Projects/FeaturedProjects.jsx
+++ b/src/Pages/Projects/FeaturedProjects.jsx
@@ -30,16 +30,7 @@ function FeaturedProjects() {
                     link="CampusFind-Admin_Backend.git"
                 />
             </div>
-           <div className="col d-flex flex-row justify-content-around">
-                <ProjectCard
-                    title="FeedFirst"
-                    image="feedfirst_card.png"
-                    tools={['Python', 'Tkinter', 'MySQL']}
-                    description={"Intuitive management system to bridge the gap between food banks and food insecure folks"}
-                    link="FeedFirst.git"
-                />
-            </div>
-           <div className="col d-flex flex-row justify-content-around">
+          <div className="col d-flex flex-row justify-content-around">
                 <ProjectCard
                     title="Heart Disease Prediction"
                     image="heart-disease-prediction.png"

--- a/src/Pages/Projects/IOTProjects.jsx
+++ b/src/Pages/Projects/IOTProjects.jsx
@@ -5,20 +5,14 @@ function IOTProjects() {
         <div className="row row-cols-xs-1 row-cols-sm-1 row-cols-md-2 row-cols-xl-3 px-4">
             <div className="col d-flex flex-row justify-content-around">
                 <ProjectCard
-                    title="CampusFind RFID Backend"
-                    image="campusfind.jpg"
-                    tools={['Python', 'Flask']}
-                    description={"A REST API server that allows CampusFind database to be updated by the RFID system"}
-                    link="campusfind-checkin-backend.git"
-                />
-            </div>
-            <div className="col d-flex flex-row justify-content-around">
-                <ProjectCard
                     title="CampusFind RFID Check-In System"
                     image="campusfind-rfid.jpg"
                     tools={['Arduino C/C++']}
                     description={"Allows users to check into rooms via RFID-cards"}
-                    link="CampusFind-RFIDStation.git"
+                    links={[
+                        { type:'Github', link: 'campusfind-rfid-backend.git', title: 'Flask Backend' }, 
+                        { type:'Github', link: 'campusfind-rfid-station.git', title: 'RFID Station' }, 
+                    ]}
                 />
             </div>
         </div>


### PR DESCRIPTION
Removed redundant feedfirst original project

Added support for multiple github links, making project cards for different repositories of the same project redundant. Removed those redundant cards